### PR TITLE
Fixed bug that `Str::endsWith` and `Str::startsWith`  with `null` wil…

### DIFF
--- a/src/Str.php
+++ b/src/Str.php
@@ -247,6 +247,7 @@ class Str
     public static function endsWith(string $haystack, $needles)
     {
         foreach ((array) $needles as $needle) {
+            $needle = (string) $needle;
             if ($needle !== '' && str_ends_with($haystack, (string) $needle)) {
                 return true;
             }
@@ -704,6 +705,7 @@ class Str
     public static function startsWith(string $haystack, $needles): bool
     {
         foreach ((array) $needles as $needle) {
+            $needle = (string) $needle;
             if ($needle !== '' && str_starts_with($haystack, (string) $needle)) {
                 return true;
             }

--- a/tests/StrTest.php
+++ b/tests/StrTest.php
@@ -169,6 +169,9 @@ class StrTest extends TestCase
         $this->assertFalse(Str::startsWith('hyperf.wiki', ['http://', 'https://']));
         $this->assertTrue(Str::startsWith('http://www.hyperf.io', 'http://'));
         $this->assertTrue(Str::startsWith('https://www.hyperf.io', ['http://', 'https://']));
+        $this->assertFalse(Str::startsWith('Hperfy', ['']));
+        $this->assertFalse(Str::startsWith('Hperfy', [null]));
+        $this->assertFalse(Str::startsWith('Hperfy', null));
     }
 
     public function testStripTags()
@@ -252,5 +255,13 @@ class StrTest extends TestCase
         $this->assertFalse(Str::contains('Hperfy', ['']));
         $this->assertFalse(Str::contains('Hperfy', [null]));
         $this->assertFalse(Str::contains('Hperfy', null));
+    }
+
+    public function testEndsWith()
+    {
+        $this->assertTrue(Str::endsWith('Hperfy', ['y']));
+        $this->assertFalse(Str::endsWith('Hperfy', ['']));
+        $this->assertFalse(Str::endsWith('Hperfy', [null]));
+        $this->assertFalse(Str::endsWith('Hperfy', null));
     }
 }


### PR DESCRIPTION
…l case the wrong result.